### PR TITLE
horizontal scrollbar at bottom of selection table was partly obscured…

### DIFF
--- a/css/selectionViewBB.css
+++ b/css/selectionViewBB.css
@@ -9,7 +9,7 @@
 }
 
 .selectView > DIV.scrollHolder {
-    height: calc(100% - 30px);
+    height: calc(100% - 40px);
     overflow: auto;
 }
 

--- a/js/selectionTableViewBB.js
+++ b/js/selectionTableViewBB.js
@@ -117,7 +117,6 @@
                     .attr ("max", "999" )
                     //~ .attr ("class", "btn btn-1 btn-1a" )
                     .style ("display", "inline-block")
-                    .text ("<last")
                     .on ("change", function (d) {
                             self.setPage(this.value);
                     });


### PR DESCRIPTION
… (because pager is taller than the text), could also remove pager on network page